### PR TITLE
UI-tweak: disable tab navigation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,8 +6,8 @@
 	* ~~HUD text pop-up event~~, or just a hovering image in general.
 	* ~~customizable pointers~~
 	* ~~PROPER class-based customizable pointers~~
-		* I sketched some hella sweet retro cursors for this for now
-	* prevent players from using the tab functionality to find hotspots
+		* *I sketched some hella sweet retro cursors for this for now*
+	* ~~prevent players from using the tab functionality to find hotspots~~
 	* anything more complex than the lamp trick i pulled is gonna require actual variables
 	* development tools
 * Sounds

--- a/engine.js
+++ b/engine.js
@@ -79,7 +79,8 @@ function buildRoom(id) {
             .attr('id', id+'_'+hotspot_id)
             .attr('shape', hotspot.area.shape)
             .attr('coords', hotspot.area.coords)
-            .attr('class', hotspot.area.class);
+            .attr('class', hotspot.area.class)
+            .attr('tabindex', -1);
         if ('click' in hotspot) {
             area.click(hotspot.click, clickHandler);
         }

--- a/style.css
+++ b/style.css
@@ -6,6 +6,12 @@
 .arrow-d {cursor: url(gfx/cursor/arrow-d.png) 20 45, s-resize;}
 .action-examine {cursor: zoom-in;}
 
+#adventure * {
+	user-select: none;
+	-webkit-user-select: none; /* Safari 3.1+ */
+	-moz-user-select: none; /* Firefox 2+ */
+	-ms-user-select: none; /* IE 10+ */
+}
 
 #overlay {
     position: fixed;


### PR DESCRIPTION
* Disables tab-navigation for map areas to avoid it hotspots being snooped out without exploration
* While we're at it, disabled user selection for the whole ``#adventure`` div